### PR TITLE
PEP8, config-file, PIP requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+#Pycharm
+/.idea/

--- a/config.py
+++ b/config.py
@@ -1,0 +1,7 @@
+# Configuration file
+
+# Yate address
+YATE_HOST = "localhost"
+
+# Yate port
+YATE_PORT = 5678

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+Twisted

--- a/sms.py
+++ b/sms.py
@@ -1,33 +1,32 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 import time
 import uuid
 from twisted.internet import reactor
 from twisted.internet.protocol import Protocol, ClientFactory
 from twisted.protocols.basic import LineReceiver
+from config import YATE_HOST, YATE_PORT
 
 
-YATE_HOST="localhost"
-YATE_PORT=5678
-
-
-def escape(str):
-    esc_string=''
-    for c in str:
+def escape(string):
+    esc_string = ''
+    for c in string:
         if c == "%" or c == ":" or ord(c) < 32:
             esc_string += "%"+chr(ord(c) + 64)
         else:
             esc_string += c
     return esc_string
 
-def unescape(str):
+
+def unescape(string):
     unesc_string = ''
     i = 0
-    while i < len(str):
-        c=str[i]
+    while i < len(string):
+        c = string[i]
         if c == "%":
             i += 1
-            c = chr(ord(str[i]) - 64)
+            c = chr(ord(string[i]) - 64)
         i += 1
         unesc_string += c
     return unesc_string
@@ -38,12 +37,12 @@ class ExtModuleProtocol(LineReceiver):
     delimiter = "\n"
     
     def sendMessage(self, message):
-        #print("sendng message: %s" % message)
+        # print("sendng message: %s" % message)
         self.transport.write(message)
         self.transport.write("\n")
 
     def enqueue(self, message_name, retvalue, **kwargs):
-        #print("Enqueueing message '%s' with params: '%s'" % (message_name, kwargs))
+        # print("Enqueueing message '%s' with params: '%s'" % (message_name, kwargs))
         params = []
         for key, value in kwargs.items():
             if value:
@@ -69,7 +68,7 @@ class ExtModuleProtocol(LineReceiver):
         self.install_handler('datacard.sms', 100)
 
     def install_handler(self, message, priority=100, filter_name=None, filter_value=None):
-        #%%>install
+        # %%>install
         install_msg = "%%%%>install:%s:%s" % (priority, escape(message))
         if filter_name:
             install_msg = "%s:%s" % (install_msg, escape(filter_name))
@@ -78,7 +77,7 @@ class ExtModuleProtocol(LineReceiver):
         self.sendMessage(install_msg)
 
     def answer(self, message_id, message_name, processed, retvalue, payload):
-        #print("Answering to server request")
+        # print("Answering to server request")
         params = []
         for key, value in payload.items():
             if value:
@@ -97,28 +96,27 @@ class ExtModuleProtocol(LineReceiver):
         self.sendMessage(message)
         
     def process_request(self, request):
-        #print("Request received: %s" % request)
+        # print("Request received: %s" % request)
         data = request.split(":")
         data = [unescape(d) for d in data]
-        #print("Data: %s. Processing message" % data)
+        # print("Data: %s. Processing message" % data)
         if data[0] == "message":
             message_id = data[1]
             message_name = data[3]
             message_data = dict(d.split("=") for d in data[5:])
-            #print("Message data: %s" % message_data)
-            #print("Message ID: %s Name: %s" % (message_id, message_name))
+            # print("Message data: %s" % message_data)
+            # print("Message ID: %s Name: %s" % (message_id, message_name))
             print("Incoming message from %s. Text: %s" % (message_data['caller'], message_data['text']))
 
 
         self.answer(message_id, message_name, False, "", {})
-    
-        
+
     def process_response(self, response):
         print("Recieved response: %s" % response) 
         data = response.split(":")
         data = [unescape(d) for d in data]
         msg_name = data.pop(0)
-        #print("Message name: %s. Data: %s" % (msg_name, data))
+        # print("Message name: %s. Data: %s" % (msg_name, data))
         
     def lineReceived(self, data):
         if not data.startswith("%%"):
@@ -128,7 +126,7 @@ class ExtModuleProtocol(LineReceiver):
         else:
             self.process_response(data[3:])
         
-    #def dataReceived(self, data):
+    # def dataReceived(self, data):
     #    print data
         
         
@@ -150,13 +148,10 @@ class ExtModuleFactory(ClientFactory):
         time.sleep(2)
         connector.connect()
 
+
 def main():
     reactor.connectTCP(YATE_HOST, YATE_PORT, ExtModuleFactory())
     reactor.run()
 
 if __name__ == '__main__':
     main()
-    
-
-
-        


### PR DESCRIPTION
Поправил оформление согласно PEP8, убрал предопределенное имя str из аргументов функций, заменив на string. Добавил глобальные переменные в отдельный конфиг-файл. Добавил файл зависимостей от внешних библиотек для установки через pip.
Еще вроде не используется в коде Protocol из пакета twisted.internet.protocol